### PR TITLE
docs: Rename title to infrastructure

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-# dutymate-infrastructure
+# infrastructure
 
 듀티메이트 서비스의 인프라 구성을 관리하는 레포지토리입니다.


### PR DESCRIPTION
This pull request includes a small change to the `README.md` file. The change updates the repository title from "dutymate-infrastructure" to "infrastructure" for clarity.