### PR TITLE
chore(backend): Migrate to S3 native state locking

### DIFF
--- a/backend.tf
+++ b/backend.tf
@@ -1,9 +1,9 @@
 terraform {
   backend "s3" {
-    bucket         = "dutymate-terraform-state-bucket"
-    key            = "terraform.tfstate"
-    region         = "ap-northeast-2"
-    dynamodb_table = "terraform-locks"
-    encrypt        = true
+    bucket       = "dutymate-terraform-state-bucket"
+    key          = "terraform.tfstate"
+    region       = "ap-northeast-2"
+    encrypt      = true
+    use_lockfile = true
   }
 }


### PR DESCRIPTION
This pull request updates the backend configuration in the `backend.tf` file to improve state locking and security.

### Key Changes

- **Migration to S3 Native State Locking**  
  Replaced the legacy `dynamodb_table` option with the new `use_lockfile = true` setting.  
  This enables [S3 native state locking](https://developer.hashicorp.com/terraform/language/settings/backends/s3#s3-native-locking) introduced in Terraform v1.10+, allowing for simplified locking without relying on DynamoDB.

- **Why This Matters**  
  The previous DynamoDB-based locking mechanism is now deprecated.  
  S3 native state locking improves maintainability and reduces the need for external dependencies like DynamoDB, enhancing both security and simplicity.

### Backend Configuration Updates

- [`backend.tf`](diffhunk://#diff-6bf4199a6f4b0f0f71825215bcbfd26c0c82c873d15083e171c6d99f209460b0L6-R7):  
  Replaced `dynamodb_table` with `use_lockfile = true` to adopt S3 native state locking.